### PR TITLE
Fix URL-to-path conversion for URLs with percent encoding

### DIFF
--- a/source/desktopfile/utils.d
+++ b/source/desktopfile/utils.d
@@ -240,7 +240,7 @@ private @trusted string escapeQuotedArgument(string value) pure {
         throw new DesktopExecException("Missing pair quote");
     }
 
-    char[] append;
+    string append;
     while(i < value.length) {
         if (value[i] == '\\' && i+1 < value.length && needQuoting(value[i+1])) {
             // this is actually does not adhere to the spec, but we need it to support some wine-generated .desktop files
@@ -255,6 +255,7 @@ private @trusted string escapeQuotedArgument(string value) pure {
             // some DEs can produce files with quoting by single quotes when there's a space in path
             // it's not actually part of the spec, but we support it
             append ~= parseQuotedPart(i, value[i], value);
+            if (append is null) append = ""; // force empty quoted strings to be output
         } else {
             append ~= value[i];
         }

--- a/source/desktopfile/utils.d
+++ b/source/desktopfile/utils.d
@@ -308,9 +308,12 @@ unittest
 
 private @trusted string urlToFilePath(string url) nothrow pure
 {
+    static import std.uri;
+
     enum protocol = "file://";
     if (url.length > protocol.length && url[0..protocol.length] == protocol) {
-        return url[protocol.length..$];
+        try return std.uri.decode(url[protocol.length..$]);
+        catch (Exception e) return url[protocol.length..$];
     } else {
         return url;
     }

--- a/source/desktopfile/utils.d
+++ b/source/desktopfile/utils.d
@@ -319,6 +319,14 @@ private @trusted string urlToFilePath(string url) nothrow pure
     }
 }
 
+unittest {
+    assert(urlToFilePath("foo/bar") == "foo/bar");
+    assert(urlToFilePath("/foo/bar") == "/foo/bar");
+    assert(urlToFilePath("file:///foo/bar") == "/foo/bar");
+    assert(urlToFilePath("file:///foo%20bar/baz") == "/foo bar/baz");
+    assert(urlToFilePath("file:///f%oo") == "/f%oo"); // handle bad encoding gracefully
+}
+
 /**
  * Expand Exec arguments (usually returned by $(D unquoteExec)) replacing field codes with given values, making the array suitable for passing to spawnProcess.
  * Deprecated field codes are ignored.


### PR DESCRIPTION
Falls back to the previous behavior as a fallback in case of encoding errors.